### PR TITLE
fix: Update ASCII art generator to use require for figlet

### DIFF
--- a/src/tools/text.ts
+++ b/src/tools/text.ts
@@ -1,6 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import * as figlet from "figlet";
 
 export function registerTextTools(server: McpServer) {
   // Text case conversion tools
@@ -274,6 +273,7 @@ Lines in text 2: ${lines2.length}`,
                           font === "big" ? "Big" : "Standard";
 
         // Generate ASCII art using figlet
+        const figlet = require('figlet');
         const asciiArt = figlet.textSync(text, {
           font: figletFont,
           horizontalLayout: 'default',


### PR DESCRIPTION
This pull request updates the `src/tools/text.ts` file to improve the handling of the `figlet` library for generating ASCII art. The changes include switching from an ES module import to a `require` statement for dynamic loading.

### Changes related to `figlet` library usage:

* Removed the static ES module import of `figlet` at the top of the file (`src/tools/text.ts`).
* Added a dynamic `require` statement for `figlet` within the ASCII art generation logic, enabling conditional loading of the library (`src/tools/text.ts`).