### PR TITLE
fix: Update ASCII art generator to use dynamic import for figlet

### DIFF
--- a/src/tools/text.ts
+++ b/src/tools/text.ts
@@ -273,8 +273,8 @@ Lines in text 2: ${lines2.length}`,
                           font === "big" ? "Big" : "Standard";
 
         // Generate ASCII art using figlet
-        const figlet = require('figlet');
-        const asciiArt = figlet.textSync(text, {
+        const figlet = await import('figlet');
+        const asciiArt = figlet.default.textSync(text, {
           font: figletFont,
           horizontalLayout: 'default',
           verticalLayout: 'default'


### PR DESCRIPTION
This pull request updates the implementation of ASCII art generation in `src/tools/text.ts` to use dynamic imports instead of `require`. This change ensures compatibility with modern JavaScript standards and improves module loading behavior.

Key change:

* [`src/tools/text.ts`](diffhunk://#diff-fd2f1946303d3eb3cd3c900095a63b4e9425384c8e7bcf58fc77cfa521aab858L276-R277): Replaced `require('figlet')` with `await import('figlet')` and updated the usage to access the default export (`[src/tools/text.tsL276-R277](diffhunk://#diff-fd2f1946303d3eb3cd3c900095a63b4e9425384c8e7bcf58fc77cfa521aab858L276-R277)`).