### PR TITLE
fix: improve regex for tool extraction and enhance HTML decoding orde…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "it-tools-mcp",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "it-tools-mcp",
-      "version": "5.2.2",
+      "version": "5.2.3",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "it-tools-mcp",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Full MCP 2025-06-18 compliant server with 121+ IT tools, logging, ping, progress tracking, cancellation, and sampling utilities",
   "type": "module",
   "main": "./build/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -804,7 +804,7 @@ async function getManifestContent(type: string): Promise<any> {
 function extractToolFromReadme(readmeContent: string, toolName: string): string | null {
   // Look for the tool in the Available Tools table
   const lines = readmeContent.split('\n');
-  const toolRegex = new RegExp(`\\|\s*\`${toolName}\`\\s*\\|`, 'i');
+  const toolRegex = new RegExp(`\\|\\s*\`${toolName}\`\\s*\\|`, 'i');
   
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];

--- a/src/tools/development/convert_list/index.ts
+++ b/src/tools/development/convert_list/index.ts
@@ -42,7 +42,11 @@ export function registerConvertList(server: McpServer) {
             result = JSON.stringify(items, null, 2);
             break;
           case 'quoted':
-            result = items.map(item => `"${item.replace(/"/g, '\\"')}"`).join(', ');
+            // Proper escaping: backslashes first, then quotes
+            result = items.map(item => {
+              const escaped = item.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+              return `"${escaped}"`;
+            }).join(', ');
             break;
           default:
             const outputSeparator = separators[outputFormat];

--- a/src/tools/encoding/decode_html/index.ts
+++ b/src/tools/encoding/decode_html/index.ts
@@ -14,12 +14,13 @@ export function registerDecodeHtml(server: McpServer) {
       readOnlyHint: false
     }
 }, async ({ text }) => {
+      // Proper HTML decoding order: decode &amp; LAST to prevent double-unescaping
       const decoded = text
-        .replace(/&amp;/g, '&')
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;/g, '"')
-        .replace(/&#39;/g, "'");
+        .replace(/&#39;/g, "'")
+        .replace(/&amp;/g, '&');  // Decode ampersand LAST
       return {
         content: [
           {

--- a/src/tools/encoding/encode_html_entities/index.ts
+++ b/src/tools/encoding/encode_html_entities/index.ts
@@ -43,8 +43,8 @@ export function registerEncodeHtmlEntities(server: McpServer) {
             ],
           };
         } else {
+          // Proper HTML decoding order: decode &amp; LAST to prevent double-unescaping
           const decoded = text
-            .replace(/&amp;/g, '&')
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
             .replace(/&quot;/g, '"')
@@ -58,7 +58,8 @@ export function registerEncodeHtmlEntities(server: McpServer) {
             .replace(/&sect;/g, '§')
             .replace(/&para;/g, '¶')
             .replace(/&dagger;/g, '†')
-            .replace(/&Dagger;/g, '‡');
+            .replace(/&Dagger;/g, '‡')
+            .replace(/&amp;/g, '&');  // Decode ampersand LAST
           
           return {
             content: [

--- a/src/tools/forensic/decode_safelink/index.ts
+++ b/src/tools/forensic/decode_safelink/index.ts
@@ -18,12 +18,20 @@ export function registerDecodeSafelink(server: McpServer) {
       try {
         const url = new URL(safelink);
         
-        // Check if it's a SafeLink URL
-        if (!url.hostname.includes('safelinks.protection.outlook.com')) {
+        // Check if it's a SafeLink URL - use secure hostname validation
+        const allowedSafeLinkHosts = [
+          'safelinks.protection.outlook.com',
+          'nam11.safelinks.protection.outlook.com',
+          'eur01.safelinks.protection.outlook.com',
+          'apc01.safelinks.protection.outlook.com',
+          'gcc02.safelinks.protection.outlook.com'
+        ];
+        
+        if (!allowedSafeLinkHosts.includes(url.hostname.toLowerCase())) {
           return {
             content: [{
               type: "text",
-              text: "This doesn't appear to be a SafeLink URL."
+              text: "This doesn't appear to be a legitimate SafeLink URL from Microsoft Outlook."
             }]
           };
         }


### PR DESCRIPTION
This pull request contains several targeted improvements and bug fixes to the toolset, focusing on more accurate data handling and security, especially in HTML entity decoding and SafeLink validation. The changes enhance correctness in output formatting and bolster the reliability of forensic and encoding utilities.

**Encoding and Decoding Improvements:**

* Ensured proper order of HTML entity decoding by moving the decoding of `&amp;` to the end of the sequence in both `decode_html` and `encode_html_entities` tools, preventing double-unescaping issues. [[1]](diffhunk://#diff-e1114d65309226fdbc6a33d109216dca0c189baa1ab814f876ab521ae92e63c5R17-R23) [[2]](diffhunk://#diff-0ccffada11573414f5ce33e9454620ce6c9299063d0e926a0c1eb3d2fea0b3acR46-L47) [[3]](diffhunk://#diff-0ccffada11573414f5ce33e9454620ce6c9299063d0e926a0c1eb3d2fea0b3acL61-R62)

**Security and Validation Enhancements:**

* Improved SafeLink URL validation in `decode_safelink` by checking against a whitelist of allowed Outlook SafeLink hostnames, strengthening detection of legitimate SafeLink URLs.

**Output Formatting Fixes:**

* Fixed quoted list output in `convert_list` to properly escape backslashes and quotes, ensuring correct and safe string formatting.

**Regex Correction:**

* Corrected the regular expression in `extractToolFromReadme` to properly match tool names in markdown tables, improving tool extraction reliability.

**Version Update:**

* Incremented the package version to `5.2.3` in `package.json` to reflect these changes.